### PR TITLE
Fix GetSceneEnum() sceneName in Windows environment

### DIFF
--- a/Editor/Scripts/Proto/EnumInfoHelper.cs
+++ b/Editor/Scripts/Proto/EnumInfoHelper.cs
@@ -99,6 +99,7 @@ namespace Google.Android.PerformanceTuner.Editor.Proto
                 if (scene == null || string.IsNullOrEmpty(scene.path)) continue;
                 var sceneName = scene.path
                     .Replace(Path.DirectorySeparatorChar, '_')
+                    .Replace(Path.AltDirectorySeparatorChar, '_')
                     .Replace(Path.GetExtension(scene.path), "")
                     .Replace(" ", "_")
                     .ToUpper();


### PR DESCRIPTION
## Problem

`EnumInfoHelper.GetSceneEnum()` generates different scene enum string for Windows and Unix-like environments.

## Why it's happening

`Path.DirectorySeparatorChar` in Windows returns `\`. However, the path for the scene asset is using `/` as separator.
Here's an example what's happening in a Windows machine:

![image](https://user-images.githubusercontent.com/10189711/102655065-6bff1380-4150-11eb-97f6-2643dd149c4f.png)


## Fix

Adding an additional replace for [Path.AltDirectorySeparatorChar](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.altdirectoryseparatorchar?view=net-5.0) will fix the problem without affecting Unix-like platoforms:

Windows returns:

- Path.DirectorySeparatorChar: `\`

- Path.AltDirectorySeparatorChar: `/`

Unix-like returns:

- Path.DirectorySeparatorChar: `/`

- Path.AltDirectorySeparatorChar: `/` (does nothing, already replaced)



