### PR TITLE
Fixed a bug that the wrong index is used for Addressable scene

### DIFF
--- a/Runtime/Scripts/AndroidPerformanceTunerInternal.cs
+++ b/Runtime/Scripts/AndroidPerformanceTunerInternal.cs
@@ -252,8 +252,12 @@ namespace Google.Android.PerformanceTuner
         {
             var annotation = new TAnnotation();
             int sceneIndex = -1;
-            if(to.buildIndex >= 0){
-                sceneIndex = to.buildIndex;
+            if (to.buildIndex >= 0)
+            {
+                // 0-index values in all enums are invalid.
+                // Scene with index 0 has enum with index 1.
+                // Increase buildIndex by one to match index in Scene enum.
+                sceneIndex = to.buildIndex + 1;
             }
 #if APT_ADDRESSABLE_PACKAGE_PRESENT
             else

--- a/Runtime/Scripts/MessageUtil.cs
+++ b/Runtime/Scripts/MessageUtil.cs
@@ -114,15 +114,13 @@ namespace Google.Android.PerformanceTuner
         /// <param name="sceneBuildIndex">The scene's build index to set.</param>
         public static void SetScene(IMessage message, int sceneBuildIndex)
         {
-            // 0-index values in all enums are invalid.
-            // Scene with index 0 has enum with index 1.
-            // Increase sceneBuildIndex by one to match index in Scene enum.
-            sceneBuildIndex++;
             var sceneEnumType = message.GetType().GetProperty(k_SceneObjectField).PropertyType;
 
-            // To prevent incorrect enum value.
-            var enumSize = Enum.GetValues(sceneEnumType).Length;
-            sceneBuildIndex = Mathf.Clamp(sceneBuildIndex, 0, enumSize - 1);
+            if (!Enum.IsDefined(sceneEnumType, sceneBuildIndex))
+            {
+                // To prevent incorrect enum value.
+                sceneBuildIndex = 0;
+            }
 
             message.GetType().InvokeMember(
                 k_SceneObjectField,


### PR DESCRIPTION
## Problem
Google Play Console shows all Addressable scenes as `'Scene':'unknown'`

## Why it's happening
The index of an Addressable scene increases from 1000, but it's clampped to the count of `Enum Scene` minus 1:
```cs
public static void SetScene(IMessage message, int sceneBuildIndex)
{
	// ...

	// To prevent incorrect enum value.
	var enumSize = Enum.GetValues(sceneEnumType).Length;
	sceneBuildIndex = Mathf.Clamp(sceneBuildIndex, 0, enumSize - 1);

	// ...
}
```